### PR TITLE
Categories filters by brand

### DIFF
--- a/Backend/test_project/categories/models.py
+++ b/Backend/test_project/categories/models.py
@@ -24,7 +24,7 @@ class Category(MPTTModel):
 
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     name = models.CharField(max_length=120, db_index=True, unique=True)
-    slug = models.SlugField(unique=True, blank=True, editable=False)
+    slug = models.SlugField(unique=True, editable=False)
     description = models.TextField(null=True, blank=True)
     parent = TreeForeignKey(   # MPTT model Field represents a parent of subcategory (if exists) in tree structure.
         "self",

--- a/Backend/test_project/categories/serializers.py
+++ b/Backend/test_project/categories/serializers.py
@@ -1,4 +1,5 @@
 from rest_framework import serializers
+from rest_framework.relations import SlugRelatedField
 
 from categories.models import Category
 
@@ -11,7 +12,11 @@ class RecursiveField(serializers.Serializer):
 
 class CategorySerializer(serializers.ModelSerializer):
     child = RecursiveField(many=True, read_only=True)
-    slug = serializers.SlugField(read_only=False)
+    parent = SlugRelatedField(    # Displays a parent category by slug value instead of weird UUID value.
+        queryset=Category.objects.all(),
+        slug_field='slug',
+        required=False
+    )
 
     class Meta:
         model = Category


### PR DESCRIPTION
1. Implemented a filtering option for each category by brand. Now filter can be applied by request a filter/ URL path and passing parameter '?brand=<brand name>' ;
2. Changed a manner of displaying a parent field for a child category. Now slug displays instead of long and weird UUID value.